### PR TITLE
Fix Build on RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,10 +25,10 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
-if on_rtd:
-	MOCK_MODULES = ['scipy', 'scipy.linalg']
-	for mod_name in MOCK_MODULES:
-    		sys.modules[mod_name] = mock.Mock()
+# if on_rtd:
+# 	MOCK_MODULES = ['scipy', 'scipy.linalg']
+#	for mod_name in MOCK_MODULES:
+#    		sys.modules[mod_name] = mock.Mock()
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 if on_rtd:
-	MOCK_MODULES = ['numpy', 'scipy', 'scipy.linalg']
+	MOCK_MODULES = ['scipy', 'scipy.linalg']
 	for mod_name in MOCK_MODULES:
     		sys.modules[mod_name] = mock.Mock()
 

--- a/tanuna/__init__.py
+++ b/tanuna/__init__.py
@@ -13,4 +13,4 @@ tanuna provides tools to work with dynamic systems. This includes
 
 from .root import *
 from . import CT_LTI
-import examples
+from . import examples


### PR DESCRIPTION
I need RTD to run plot_directives. Apparently, RTD has the required tools installed but numpy is overloaded by the mocked module => stop mocking numpy on RTD.
